### PR TITLE
Increase default max steps to 20

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ async def run_agent_loop(
     prompt: str,
     tools: list[ToolUnionParam],
     tool_handlers: dict[str, Callable[..., Any]],
-    max_steps: int = 5,
+    max_steps: int = 20,
     model: str = "claude-3-5-haiku-latest",
     verbose: bool = True,
 ) -> Any | None:


### PR DESCRIPTION
Submissions often reach the target pass rate by setting a specific
number of maximum steps such that the model doesn't manage to submit
an answer in every run. We should discourage this by having a high
number of max steps by default.
